### PR TITLE
fix: only affect tabs of window where action was requested on

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 async function removeDuplicateTabs() {
-  const tabs = await browser.tabs.query({});
+  const tabs = await browser.tabs.query({ currentWindow: true });
 
   const duplicateIds = [];
   const bins = {};
@@ -16,7 +16,7 @@ async function removeDuplicateTabs() {
 }
 
 async function groupTabsByDomain() {
-  const tabs = await browser.tabs.query({});
+  const tabs = await browser.tabs.query({ currentWindow: true });
 
   const domainGroups = {};
 


### PR DESCRIPTION
# Proposal

## Why

Extension should only affect tabs in current browser window instance.

## What

Narrows tabs to only those in current window instance.

## Related

Fixes #6 